### PR TITLE
Dev/custom material theme

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -20,7 +20,8 @@
       "testTsconfig": "tsconfig.spec.json",
       "prefix": "ugly",
       "styles": [
-        "styles.css"
+        "styles.css",
+        "ugly-aesthetics.scss"
       ],
       "scripts": [
         "../node_modules/requirejs/require.js"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "karma-coverage-istanbul-reporter": "^0.2.0",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
+    "node-sass": "^4.5.2",
     "node-watch": "^0.4.1",
     "protractor": "~5.1.0",
     "ts-node": "~2.0.0",

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,5 +1,4 @@
 /* You can add global styles to this file, and also import other style files */
-@import '~@angular/material/prebuilt-themes/indigo-pink.css';
 
 @font-face {
   font-family: 'Material Icons';
@@ -47,12 +46,5 @@ body {
 
 html {
   height: 100%;
-}
-
-/* Small change to this colour to fit better with colours we use in
-   visualisations */
-
-.mat-toolbar, .mat-toolbar.mat-primary {
-  background: #0868ac;
 }
 

--- a/src/ugly-aesthetics.scss
+++ b/src/ugly-aesthetics.scss
@@ -1,0 +1,24 @@
+@import '~@angular/material/theming';
+// Plus imports for other components in your app.
+
+// Include the common styles for Angular Material. We include this here so that you only
+// have to load a single css file for Angular Material in your app.
+// Be sure that you only ever include this mixin once!
+@include mat-core();
+
+// Define the palettes for your theme using the Material Design palettes available in palette.scss
+// (imported above). For each palette, you can optionally specify a default, lighter, and darker
+// hue.
+$candy-app-primary: mat-palette($mat-indigo);
+$candy-app-accent:  mat-palette($mat-pink, A200, A100, A400);
+
+// The warn palette is optional (defaults to red).
+$candy-app-warn:    mat-palette($mat-red);
+
+// Create the theme object (a Sass map containing all of the palettes).
+$candy-app-theme: mat-light-theme($candy-app-primary, $candy-app-accent, $candy-app-warn);
+
+// Include theme styles for core and each component used in your app.
+// Alternatively, you can import and @include the theme mixins for each component
+// that you are using.
+@include angular-material-theme($candy-app-theme);

--- a/src/ugly-aesthetics.scss
+++ b/src/ugly-aesthetics.scss
@@ -6,10 +6,29 @@
 // Be sure that you only ever include this mixin once!
 @include mat-core();
 
+// Generated with http://mcg.mbitson.com - seeded with base colour of #0868ac
+// The contrast colours are taken from $mat-indigo
+$md-ugly-blue: map-merge($mat-indigo, (
+  50 : #e1edf5,
+  100 : #b5d2e6,
+  200 : #84b4d6,
+  300 : #5295c5,
+  400 : #2d7fb8,
+  500 : #0868ac,
+  600 : #0760a5,
+  700 : #06559b,
+  800 : #044b92,
+  900 : #023a82,
+  A100 : #afccff,
+  A200 : #7cabff,
+  A400 : #498bff,
+  A700 : #307bff,
+));
+
 // Define the palettes for your theme using the Material Design palettes available in palette.scss
 // (imported above). For each palette, you can optionally specify a default, lighter, and darker
 // hue.
-$candy-app-primary: mat-palette($mat-indigo);
+$candy-app-primary: mat-palette($md-ugly-blue);
 $candy-app-accent:  mat-palette($mat-pink, A200, A100, A400);
 
 // The warn palette is optional (defaults to red).

--- a/yarn.lock
+++ b/yarn.lock
@@ -3721,7 +3721,7 @@ node-pre-gyp@^0.6.29:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
-node-sass@^4.3.0:
+node-sass, node-sass@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.5.2.tgz#4012fa2bd129b1d6365117e88d9da0500d99da64"
   dependencies:


### PR DESCRIPTION
Setup project to build a sass file defining a custom material theme into the generate styles bundle, as per the angular/material documentation - override the indigo palette with a custom blue one closer to our chosen visualisation colours. 